### PR TITLE
Fix unreliable detection of “help” option

### DIFF
--- a/Sources/Command.swift
+++ b/Sources/Command.swift
@@ -178,7 +178,7 @@ public struct Command: CommandIndexable {
 		let commandEvaluation =  try subEvaluate(arguments:arguments.dropFirst().map { $0 })
 
 		// If help option is present in the command evaluation, print help.
-		if commandEvaluation.options.contains(where: { $0.flag == "help" }) {
+		if commandEvaluation.options.contains(where: { $0.flag == Option.help.flag }) {
 			print(help(superCommands: []))
 			return commandEvaluation
 		}
@@ -192,7 +192,7 @@ public struct Command: CommandIndexable {
 		while let next = current.subEvaluation {
 			current = next
 			
-			if current.options.contains(where: { $0.flag == "help" }) {
+			if current.options.contains(where: { $0.flag == Option.help.flag }) {
 				print(current.describer.help(superCommands: superCommands))
 			}
 			superCommands.append(current.describer)
@@ -228,7 +228,7 @@ public struct Command: CommandIndexable {
 				let option = OptionEvaluation(string: next) {
 				
 				// If option is help, stop evaluating
-				if option.flag == "help" {
+				if option.flag == Option.help.flag {
 					evaluation.options.append(option)
 					return evaluation
 				}

--- a/Sources/CommandEvaluation.swift
+++ b/Sources/CommandEvaluation.swift
@@ -78,7 +78,7 @@ public struct CommandEvaluation: CommandIndexable {
 	public func performCallbacks() throws {
 
 		// Do not perform callbacks if help is in any option
-		if allOptions.contains(where: { $0.flag == "help" }) {
+		if allOptions.contains(where: { $0.flag == Option.help.flag }) {
 			return
 		}
 		


### PR DESCRIPTION
The console output of this program:

```swift
import CommandCougar

func execution(evaluation: CommandEvaluation) throws {
    print(
        "\(evaluation.name) evaluated with " +
            "options: \(evaluation.options) " +
        "and parameters \(evaluation.parameters)"
    )
}

var dummyCommand = Command(
    name: "dummy",
    overview: "Dummy command",
    callback: execution,
    options: [],
    parameters: []
)

do {
    let args = ["dummy", "-h"]
    let evaluation = try dummyCommand.evaluate(arguments: args)
    try evaluation.performCallbacks()
} catch {
    print(error)
    print(dummyCommand.help())
}
```

… is this:

> ```
> dummy evaluated with options: [-h] and parameters []
> ```

… while the expected console output would have been this:

> ```
> OVERVIEW: Dummy command
> 
> USAGE: dummy [options] 
> 
> OPTIONS:
>    -h, --help                    The help menu
> ```

There are four occurrences of `<option>.flag == "help"` in the source, which fail to match when providing `-h`, instead of `--help`. A quick fix for this is to replace `"help"` with `Option.help.flag`.